### PR TITLE
remove index mapping between reco track and reco vertex, keep the LUT

### DIFF
--- a/CustomNanoAOD/plugins/SVTrackTableProducer.cc
+++ b/CustomNanoAOD/plugins/SVTrackTableProducer.cc
@@ -87,7 +87,7 @@ SVTrackTableProducer::SVTrackTableProducer(const edm::ParameterSet& params)
 
 {
   produces<nanoaod::FlatTable>("svs");
-  produces<nanoaod::FlatTable>("tks");
+  //produces<nanoaod::FlatTable>("tks");
   produces<nanoaod::FlatTable>("svstksidx"); // secondary vertex track index
 }
 
@@ -248,63 +248,67 @@ void SVTrackTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
   }
 
 
-  // Now vertex table is produced, let's make track tables
-  const auto& tracks = iEvent.get(tksrc_);
-  auto ntrack = tracks.size();
-  auto tktab = std::make_unique<nanoaod::FlatTable>(ntrack, tkName_, false, true);
+  //This part used to generate the index mapping between reco vertex and reco tracks, a bette way (LUT) is used now so this part is commented out
+  // -------------------------------------------------------------
+  //
+  //// Now vertex table is produced, let's make track tables
+  //const auto& tracks = iEvent.get(tksrc_);
+  //auto ntrack = tracks.size();
+  ////auto tktab = std::make_unique<nanoaod::FlatTable>(ntrack, tkName_, false, true);
 
-  std::vector<int> key(ntrack, -1);
+  //std::vector<int> key(ntrack, -1);
  
 
-  for (size_t i = 0; i < ntrack; ++i) {
-    const auto& tk = tracks.at(i);
-    if (debug){
-      std::cout << "reco track " << i << " pt " << tk.pt() << " eta " << tk.eta() << " phi " << tk.phi() << std::endl;
-    }
-    // match vertices by matching tracks
-    // FIXME: This algorithm assumes tracks are not reused for different vertices, so it might be a problem when it is not the case
-    int matched_vtx_idx = -1;
+  //for (size_t i = 0; i < ntrack; ++i) {
+  //  const auto& tk = tracks.at(i);
+  //  if (debug){
+  //    std::cout << "reco track " << i << " pt " << tk.pt() << " eta " << tk.eta() << " phi " << tk.phi() << std::endl;
+  //  }
+  //  // match vertices by matching tracks
+  //  // FIXME: This algorithm assumes tracks are not reused for different vertices, so it might be a problem when it is not the case
+  //  int matched_vtx_idx = -1;
 
-    for (size_t ivtx=0; ivtx<vertices->size(); ++ivtx) {
-      const reco::Vertex& vtx = vertices->at(ivtx);
-      double match_threshold = 1.1;
-      // for each LLP, compare the matched tracks with tracks in the reco vertex 
-      
-      if (debug){
-        std::cout << "reco vertex " << ivtx << " x: " << vtx.x() << " y: " << vtx.y() << " z: " << vtx.z()  << " tracks " << std::endl;
-        for (auto v_tk = vtx.tracks_begin(), vtke = vtx.tracks_end(); v_tk != vtke; ++v_tk){
-          std::cout << "  pt: " << (*v_tk)->pt() << " eta: " << (*v_tk)->eta() << " phi: " << (*v_tk)->phi() << std::endl;
-        }
-      }
+  //  for (size_t ivtx=0; ivtx<vertices->size(); ++ivtx) {
+  //    const reco::Vertex& vtx = vertices->at(ivtx);
+  //    double match_threshold = 1.1;
+  //    // for each LLP, compare the matched tracks with tracks in the reco vertex 
+  //    
+  //    if (debug){
+  //      std::cout << "reco vertex " << ivtx << " x: " << vtx.x() << " y: " << vtx.y() << " z: " << vtx.z()  << " tracks " << std::endl;
+  //      for (auto v_tk = vtx.tracks_begin(), vtke = vtx.tracks_end(); v_tk != vtke; ++v_tk){
+  //        std::cout << "  pt: " << (*v_tk)->pt() << " eta: " << (*v_tk)->eta() << " phi: " << (*v_tk)->phi() << std::endl;
+  //      }
+  //    }
 
-      for (auto v_tk = vtx.tracks_begin(), vtke = vtx.tracks_end(); v_tk != vtke; ++v_tk){
-        double dpt = fabs(tk.pt() - (*v_tk)->pt()) + 1;
-        double deta = fabs(tk.eta() - (*v_tk)->eta()) + 1;
-        double dphi = fabs(tk.phi() - (*v_tk)->phi()) + 1;
-        if (dpt * deta * dphi < match_threshold){
-          matched_vtx_idx = (int) ivtx;
+  //    for (auto v_tk = vtx.tracks_begin(), vtke = vtx.tracks_end(); v_tk != vtke; ++v_tk){
+  //      double dpt = fabs(tk.pt() - (*v_tk)->pt()) + 1;
+  //      double deta = fabs(tk.eta() - (*v_tk)->eta()) + 1;
+  //      double dphi = fabs(tk.phi() - (*v_tk)->phi()) + 1;
+  //      if (dpt * deta * dphi < match_threshold){
+  //        matched_vtx_idx = (int) ivtx;
 
-          // First IdxLUT implementation (OLD)
-          // -------------------------------------
-          // SecVtxIdx.push_back(ivtx);
-          // TrackIdx.push_back(i);
-          // -------------------------------------
+  //        // First IdxLUT implementation (OLD)
+  //        // -------------------------------------
+  //        // SecVtxIdx.push_back(ivtx);
+  //        // TrackIdx.push_back(i);
+  //        // -------------------------------------
 
-          if (debug) {
-            std::cout << "  track matched: " << std::endl;
-            std::cout << "  |->  gen pt " << tk.pt() << " eta " << tk.eta() << " phi " << tk.phi() << std::endl;
-            std::cout << "  --> reco pt " << (*v_tk)->pt() << " eta " << (*v_tk)->eta() << " phi " << (*v_tk)->phi() << std::endl;
-          }
-          break;
-        }
-      }
-      if (matched_vtx_idx!=-1)
-        break;
-    }
-    if (debug)
-      std::cout << "track matched with vertex " << matched_vtx_idx << std::endl;
-    key[i] = matched_vtx_idx;
-  }
+  //        if (debug) {
+  //          std::cout << "  track matched: " << std::endl;
+  //          std::cout << "  |->  gen pt " << tk.pt() << " eta " << tk.eta() << " phi " << tk.phi() << std::endl;
+  //          std::cout << "  --> reco pt " << (*v_tk)->pt() << " eta " << (*v_tk)->eta() << " phi " << (*v_tk)->phi() << std::endl;
+  //        }
+  //        break;
+  //      }
+  //    }
+  //    if (matched_vtx_idx!=-1)
+  //      break;
+  //  }
+  //  if (debug)
+  //    std::cout << "track matched with vertex " << matched_vtx_idx << std::endl;
+  //  key[i] = matched_vtx_idx;
+  //}
+  // -------------------------------------------------------------
 
   // LUT: lookup table
   // ------------------------------------------------------------------------------
@@ -322,10 +326,11 @@ void SVTrackTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
   // ----------------------------------------------------------------------------------------------------
 
 
-  tktab->addColumn<int>(tkbranchName_, key, tkbranchDoc_, nanoaod::FlatTable::IntColumn);
+  // This is the previous track vertex mapping (similar functionality compared with LUT)
+  //tktab->addColumn<int>(tkbranchName_, key, tkbranchDoc_, nanoaod::FlatTable::IntColumn);
 
   iEvent.put(std::move(svsTable), "svs");
-  iEvent.put(std::move(tktab), "tks");
+  //iEvent.put(std::move(tktab), "tks");
   iEvent.put(std::move(LUT), "svstksidx");
 }
 


### PR DESCRIPTION
This is an additional edit in the GenMapping branch. It removes the index mapping between reco vertex and reco track. The LUT is kept as the nominal method of mapping reco track with reco vertices.