### PR TITLE
added matching between LLP and reco vtx

### DIFF
--- a/CustomNanoAOD/python/LLPTable_cfi.py
+++ b/CustomNanoAOD/python/LLPTable_cfi.py
@@ -9,5 +9,6 @@ LLPTable = cms.EDProducer("LLPTableProducer",
     LSPid_ = cms.int32(1000022),
     pvToken = cms.InputTag("offlineSlimmedPrimaryVertices"),
     tkToken = cms.InputTag("VertexTracksFilter","seed"),
+    svToken = cms.InputTag("IVFSecondaryVerticesSoftDV"),
     debug = cms.bool(False),
     )

--- a/CustomNanoAOD/test/customNanoAOD_cfg.py
+++ b/CustomNanoAOD/test/customNanoAOD_cfg.py
@@ -50,7 +50,7 @@ process.load("TrackingTools/TransientTrack/TransientTrackBuilder_cfi")
 
 
 process.maxEvents = cms.untracked.PSet(
-    # input = cms.untracked.int32(-1)
+    #input = cms.untracked.int32(100)
 )
 
 MessageLogger = cms.Service("MessageLogger")

--- a/SoftDVDataFormats/interface/GenInfo.h
+++ b/SoftDVDataFormats/interface/GenInfo.h
@@ -93,6 +93,8 @@ namespace SoftDV {
   SoftDV::MatchResult matchtracks(const reco::GenParticle& gtk, const edm::Handle<reco::TrackCollection>& tracks, const SoftDV::Point& refpoint);
 
   SoftDV::Match matchchi2(const reco::GenParticle& gtk, const reco::TrackRef& rtk, const SoftDV::Point& refpoint);
+
+  bool pass_gentk(const reco::GenParticle& gtk, const SoftDV::Point& refpoint);
 }
 double gen_dxy(const reco::GenParticle& gtk, const SoftDV::Point& refpoint); 
 double gen_dz(const reco::GenParticle& gtk, const SoftDV::Point& refpoint);

--- a/SoftDVDataFormats/src/GenInfo.cc
+++ b/SoftDVDataFormats/src/GenInfo.cc
@@ -149,6 +149,16 @@ SoftDV::Match SoftDV::matchchi2(const reco::GenParticle& gtk, const reco::TrackR
   return std::pair<double,std::vector<double>>(0.25*asum,m);
 }
 
+bool SoftDV::pass_gentk(const reco::GenParticle& gtk, const SoftDV::Point& refpoint){
+  if (gtk.status()!=1) return false;
+  if ( (gtk.charge()==0) || (fabs(gtk.charge())<1) ) return false;
+  if (gtk.pt()<0.5 || fabs(gtk.eta()) > 2.5 ) return false;
+  double dxy_gen = gen_dxy(gtk,refpoint);
+  if (dxy_gen<0.005) return false;
+
+  return true;  
+}
+
 double gen_dxy(const reco::GenParticle& gtk, const SoftDV::Point& refpoint){
   // calculate dxy for gen track
   double r = 88.*gtk.pt();


### PR DESCRIPTION
Added matching between LLP and reco vertex:
- Match by gen level LLP decay daughters (match index and number of matched daughters are saved)
- Match by distance between LLP decay point and vertex position (match index and distance significance are saved)