### PR TITLE
configuration files are modified to accept command-line arguments. README files are updated.

### DIFF
--- a/CustomMiniAOD/README.md
+++ b/CustomMiniAOD/README.md
@@ -1,23 +1,24 @@
 # CustomMiniAOD
 MiniAOD customisation for soft displaced vertex search.
 
-The production starts with the generation of MiniAOD starting with some AOD files. 
+The whole production begins with the generation of MiniAOD starting with some AOD files. 
 Datasets belonging to different eras and different Runs might have different conditions, calibrations, and detector alignment info associated with them. Therefore there are more than one configuration files.
 
 
 `configuration` subdirectory contains the recommended config files we use for the production. `test`, `test_cfg`, `testK` contain some codes and other files when we test out some new features during the development phase. These are more like a user area within the repository.  
 
-**Attention**: So far only 2018 configs are tested. Check them once again when MC and data of other years are included in the analysis.
+**Attention**: So far only 2018 configs are tested. Check the others once again when MC and data of other years are included in the analysis.
 
 `plugins` contain the C++ codes some of whose parameters are configurable to some extent. `python` directory contains the configurations for module initialisations (cfi), or configuration file fragments (cff). 
 
 
-Below you can see an example to run a MiniAOD customisation.
+Below you can see an example to run a custom MiniAOD generation:
 
 ```bash
 cmsRun -n 4 CustomMiniAOD/configuration/Data_UL18_CustomMiniAOD.py inputFiles="file:/path_to_local_file.root" outputFile="path_to output file.root" maxEvents=-1
 ```
-
+<br>
+    
 MiniAOD outputs can be inspected through root. Just remember that the saved objects are C++ objects, so you need to know which variables and functions are available. e.g.
 
 ```c++

--- a/CustomMiniAOD/README.md
+++ b/CustomMiniAOD/README.md
@@ -1,0 +1,36 @@
+# CustomMiniAOD
+MiniAOD customisation for soft displaced vertex search.
+
+The production starts with the generation of MiniAOD starting with some AOD files. 
+Datasets belonging to different eras and different Runs might have different conditions, calibrations, and detector alignment info associated with them. Therefore there are more than one configuration files.
+
+
+`configuration` subdirectory contains the recommended config files we use for the production. `test`, `test_cfg`, `testK` contain some codes and other files when we test out some new features during the development phase. These are more like a user area within the repository.  
+
+**Attention**: So far only 2018 configs are tested. Check them once again when MC and data of other years are included in the analysis.
+
+`plugins` contain the C++ codes some of whose parameters are configurable to some extent. `python` directory contains the configurations for module initialisations (cfi), or configuration file fragments (cff). 
+
+
+Below you can see an example to run a MiniAOD customisation.
+
+```bash
+cmsRun -n 4 CustomMiniAOD/configuration/Data_UL18_CustomMiniAOD.py inputFiles="file:/path_to_local_file.root" outputFile="path_to output file.root" maxEvents=-1
+```
+
+MiniAOD outputs can be inspected through root. Just remember that the saved objects are C++ objects, so you need to know which variables and functions are available. e.g.
+
+```c++
+root [1] Events->Scan("recoTracks_FilterIsolateTracks_seed_MINI.obj->pt():SoftDVPFIsolations_FilterIsolateTracks_isolationDR03_MINI.obj->chargedHadronIso()")
+***********************************************
+*    Row   * Instance * recoTrack * SoftDVPFI *
+***********************************************
+*        0 *        0 * 0.5710884 *         0 *
+*        0 *        1 * 0.7666415 *         0 *
+*        0 *        2 * 2.0206983 *         0 *
+*        0 *        3 * 2.4911582 * 2.5036621 *
+*        0 *        4 * 0.5610689 *         0 *
+*        0 *        5 * 0.9531079 *         0 *
+Type <CR> to continue or q to quit ==> 
+
+```

--- a/CustomMiniAOD/configuration/Data_UL16_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/Data_UL16_CustomMiniAOD.py
@@ -4,11 +4,15 @@
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
 # with command line options: --python_filename Data_UL16_CustomMiniAOD.py --filein file:AOD.root --fileout MiniAOD.root --step PAT --eventcontent MINIAOD --datatier MINIAOD --customise Configuration/DataProcessing/Utils.addMonitoring --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_customise_SoftDisplacedVertices --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_filter_SoftDisplacedVertices --conditions 106X_dataRun2_v35 --procModifiers run2_miniAOD_UL --geometry DB:Extended --era Run2_2016 --runUnscheduled --no_exec --data
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
 
 from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 
-process = cms.Process('PAT',Run2_2016,run2_miniAOD_UL)
+process = cms.Process('MINI',Run2_2016,run2_miniAOD_UL)
+
+options = VarParsing ('analysis')
+options.parseArguments()
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -23,12 +27,12 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1)
+    input = cms.untracked.int32(options.maxEvents)
 )
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:AOD.root'),
+    fileNames = cms.untracked.vstring(options.inputFiles),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -55,7 +59,7 @@ process.MINIAODoutput = cms.OutputModule("PoolOutputModule",
     dropMetaData = cms.untracked.string('ALL'),
     eventAutoFlushCompressedSize = cms.untracked.int32(-900),
     fastCloning = cms.untracked.bool(False),
-    fileName = cms.untracked.string('MiniAOD.root'),
+    fileName = cms.untracked.string(options.outputFile),
     outputCommands = process.MINIAODEventContent.outputCommands,
     overrideBranchesSplitLevel = cms.untracked.VPSet(
         cms.untracked.PSet(

--- a/CustomMiniAOD/configuration/Data_UL16_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/Data_UL16_CustomMiniAOD.py
@@ -193,7 +193,7 @@ process = miniAOD_customizeAllData(process)
 # End of customisation functions
 
 # Customisation from command line
-
+process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=1000
 # Add early deletion of temporary data products to reduce peak memory need
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
 process = customiseEarlyDelete(process)

--- a/CustomMiniAOD/configuration/Data_UL16preVFP_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/Data_UL16preVFP_CustomMiniAOD.py
@@ -193,7 +193,7 @@ process = miniAOD_customizeAllData(process)
 # End of customisation functions
 
 # Customisation from command line
-
+process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=1000
 # Add early deletion of temporary data products to reduce peak memory need
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
 process = customiseEarlyDelete(process)

--- a/CustomMiniAOD/configuration/Data_UL16preVFP_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/Data_UL16preVFP_CustomMiniAOD.py
@@ -4,11 +4,15 @@
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
 # with command line options: --python_filename Data_UL16preVFP_CustomMiniAOD.py --filein file:AOD.root --fileout MiniAOD.root --step PAT --eventcontent MINIAOD --datatier MINIAOD --customise Configuration/DataProcessing/Utils.addMonitoring --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_customise_SoftDisplacedVertices --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_filter_SoftDisplacedVertices --conditions 106X_dataRun2_v35 --procModifiers run2_miniAOD_UL --geometry DB:Extended --era Run2_2016_HIPM --runUnscheduled --no_exec --data
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
 
 from Configuration.Eras.Era_Run2_2016_HIPM_cff import Run2_2016_HIPM
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 
-process = cms.Process('PAT',Run2_2016_HIPM,run2_miniAOD_UL)
+process = cms.Process('MINI',Run2_2016_HIPM,run2_miniAOD_UL)
+
+options = VarParsing ('analysis')
+options.parseArguments()
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -23,12 +27,12 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1)
+    input = cms.untracked.int32(options.maxEvents)
 )
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:AOD.root'),
+    fileNames = cms.untracked.vstring(options.inputFiles),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -55,7 +59,7 @@ process.MINIAODoutput = cms.OutputModule("PoolOutputModule",
     dropMetaData = cms.untracked.string('ALL'),
     eventAutoFlushCompressedSize = cms.untracked.int32(-900),
     fastCloning = cms.untracked.bool(False),
-    fileName = cms.untracked.string('MiniAOD.root'),
+    fileName = cms.untracked.string(options.outputFile),
     outputCommands = process.MINIAODEventContent.outputCommands,
     overrideBranchesSplitLevel = cms.untracked.VPSet(
         cms.untracked.PSet(

--- a/CustomMiniAOD/configuration/Data_UL17_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/Data_UL17_CustomMiniAOD.py
@@ -193,7 +193,7 @@ process = miniAOD_customizeAllData(process)
 # End of customisation functions
 
 # Customisation from command line
-
+process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=1000
 # Add early deletion of temporary data products to reduce peak memory need
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
 process = customiseEarlyDelete(process)

--- a/CustomMiniAOD/configuration/Data_UL17_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/Data_UL17_CustomMiniAOD.py
@@ -4,11 +4,15 @@
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
 # with command line options: --python_filename Data_UL17_CustomMiniAOD.py --filein file:AOD.root --fileout MiniAOD.root --step PAT --eventcontent MINIAOD --datatier MINIAOD --customise Configuration/DataProcessing/Utils.addMonitoring --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_customise_SoftDisplacedVertices --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_filter_SoftDisplacedVertices --conditions 106X_dataRun2_v35 --procModifiers run2_miniAOD_UL --geometry DB:Extended --era Run2_2017 --runUnscheduled --no_exec --data
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
 
 from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 
-process = cms.Process('PAT',Run2_2017,run2_miniAOD_UL)
+process = cms.Process('MINI',Run2_2017,run2_miniAOD_UL)
+
+options = VarParsing ('analysis')
+options.parseArguments()
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -23,12 +27,12 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1)
+    input = cms.untracked.int32(options.maxEvents)
 )
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:AOD.root'),
+    fileNames = cms.untracked.vstring(options.inputFiles),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -55,7 +59,7 @@ process.MINIAODoutput = cms.OutputModule("PoolOutputModule",
     dropMetaData = cms.untracked.string('ALL'),
     eventAutoFlushCompressedSize = cms.untracked.int32(-900),
     fastCloning = cms.untracked.bool(False),
-    fileName = cms.untracked.string('MiniAOD.root'),
+    fileName = cms.untracked.string(options.outputFile),
     outputCommands = process.MINIAODEventContent.outputCommands,
     overrideBranchesSplitLevel = cms.untracked.VPSet(
         cms.untracked.PSet(

--- a/CustomMiniAOD/configuration/Data_UL18_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/Data_UL18_CustomMiniAOD.py
@@ -4,11 +4,15 @@
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
 # with command line options: --python_filename Data_UL18_CustomMiniAOD.py --filein file:AOD.root --fileout MiniAOD.root --step PAT --eventcontent MINIAOD --datatier MINIAOD --customise Configuration/DataProcessing/Utils.addMonitoring --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_customise_SoftDisplacedVertices --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_filter_SoftDisplacedVertices --conditions 106X_dataRun2_v35 --procModifiers run2_miniAOD_UL --geometry DB:Extended --era Run2_2018 --runUnscheduled --no_exec --data
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
 
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 
-process = cms.Process('PAT',Run2_2018,run2_miniAOD_UL)
+process = cms.Process('MINI',Run2_2018,run2_miniAOD_UL)
+
+options = VarParsing ('analysis')
+options.parseArguments()
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -23,12 +27,12 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1)
+    input = cms.untracked.int32(options.maxEvents)
 )
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:AOD.root'),
+    fileNames = cms.untracked.vstring(options.inputFiles),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -55,7 +59,7 @@ process.MINIAODoutput = cms.OutputModule("PoolOutputModule",
     dropMetaData = cms.untracked.string('ALL'),
     eventAutoFlushCompressedSize = cms.untracked.int32(-900),
     fastCloning = cms.untracked.bool(False),
-    fileName = cms.untracked.string('MiniAOD.root'),
+    fileName = cms.untracked.string(options.outputFile),
     outputCommands = process.MINIAODEventContent.outputCommands,
     overrideBranchesSplitLevel = cms.untracked.VPSet(
         cms.untracked.PSet(

--- a/CustomMiniAOD/configuration/Data_UL18_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/Data_UL18_CustomMiniAOD.py
@@ -193,7 +193,7 @@ process = miniAOD_customizeAllData(process)
 # End of customisation functions
 
 # Customisation from command line
-
+process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=1000
 # Add early deletion of temporary data products to reduce peak memory need
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
 process = customiseEarlyDelete(process)

--- a/CustomMiniAOD/configuration/MC_UL16_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/MC_UL16_CustomMiniAOD.py
@@ -4,11 +4,15 @@
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
 # with command line options: CustomMiniAOD --python_filename MC_UL16_CustomMiniAOD.py --filein file:AOD.root --fileout MiniAOD.root --step PAT --eventcontent MINIAODSIM --datatier MINIAODSIM --customise Configuration/DataProcessing/Utils.addMonitoring --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_customise_SoftDisplacedVerticesMC --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_filter_SoftDisplacedVertices --conditions 106X_mcRun2_asymptotic_v17 --procModifiers run2_miniAOD_UL --geometry DB:Extended --era Run2_2016 --runUnscheduled --no_exec --mc
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
 
 from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 
-process = cms.Process('PAT',Run2_2016,run2_miniAOD_UL)
+process = cms.Process('MINI',Run2_2016,run2_miniAOD_UL)
+
+options = VarParsing ('analysis')
+options.parseArguments()
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -24,12 +28,12 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1)
+    input = cms.untracked.int32(options.maxEvents)
 )
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:AOD.root'),
+    fileNames = cms.untracked.vstring(options.inputFiles),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -56,7 +60,7 @@ process.MINIAODSIMoutput = cms.OutputModule("PoolOutputModule",
     dropMetaData = cms.untracked.string('ALL'),
     eventAutoFlushCompressedSize = cms.untracked.int32(-900),
     fastCloning = cms.untracked.bool(False),
-    fileName = cms.untracked.string('MiniAOD.root'),
+    fileName = cms.untracked.string(options.outputFile),
     outputCommands = process.MINIAODSIMEventContent.outputCommands,
     overrideBranchesSplitLevel = cms.untracked.VPSet(
         cms.untracked.PSet(

--- a/CustomMiniAOD/configuration/MC_UL16_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/MC_UL16_CustomMiniAOD.py
@@ -194,7 +194,7 @@ process = miniAOD_customizeAllMC(process)
 # End of customisation functions
 
 # Customisation from command line
-
+process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=1000
 # Add early deletion of temporary data products to reduce peak memory need
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
 process = customiseEarlyDelete(process)

--- a/CustomMiniAOD/configuration/MC_UL16preVFP_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/MC_UL16preVFP_CustomMiniAOD.py
@@ -194,7 +194,7 @@ process = miniAOD_customizeAllMC(process)
 # End of customisation functions
 
 # Customisation from command line
-
+process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=1000
 # Add early deletion of temporary data products to reduce peak memory need
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
 process = customiseEarlyDelete(process)

--- a/CustomMiniAOD/configuration/MC_UL16preVFP_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/MC_UL16preVFP_CustomMiniAOD.py
@@ -4,11 +4,15 @@
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
 # with command line options: CustomMiniAOD --python_filename MC_UL16preVFP_CustomMiniAOD.py --filein file:AOD.root --fileout MiniAOD.root --step PAT --eventcontent MINIAODSIM --datatier MINIAODSIM --customise Configuration/DataProcessing/Utils.addMonitoring --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_customise_SoftDisplacedVerticesMC --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_filter_SoftDisplacedVertices --conditions 106X_mcRun2_asymptotic_preVFP_v11 --procModifiers run2_miniAOD_UL --geometry DB:Extended --era Run2_2016_HIPM --runUnscheduled --no_exec --mc
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
 
 from Configuration.Eras.Era_Run2_2016_HIPM_cff import Run2_2016_HIPM
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 
-process = cms.Process('PAT',Run2_2016_HIPM,run2_miniAOD_UL)
+process = cms.Process('MINI',Run2_2016_HIPM,run2_miniAOD_UL)
+
+options = VarParsing ('analysis')
+options.parseArguments()
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -24,12 +28,12 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1)
+    input = cms.untracked.int32(options.maxEvents)
 )
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:AOD.root'),
+    fileNames = cms.untracked.vstring(options.inputFiles),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -56,7 +60,7 @@ process.MINIAODSIMoutput = cms.OutputModule("PoolOutputModule",
     dropMetaData = cms.untracked.string('ALL'),
     eventAutoFlushCompressedSize = cms.untracked.int32(-900),
     fastCloning = cms.untracked.bool(False),
-    fileName = cms.untracked.string('MiniAOD.root'),
+    fileName = cms.untracked.string(options.outputFile),
     outputCommands = process.MINIAODSIMEventContent.outputCommands,
     overrideBranchesSplitLevel = cms.untracked.VPSet(
         cms.untracked.PSet(

--- a/CustomMiniAOD/configuration/MC_UL17_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/MC_UL17_CustomMiniAOD.py
@@ -4,11 +4,15 @@
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
 # with command line options: CustomMiniAOD --python_filename MC_UL17_CustomMiniAOD.py --filein file:AOD.root --fileout MiniAOD.root --step PAT --eventcontent MINIAODSIM --datatier MINIAODSIM --customise Configuration/DataProcessing/Utils.addMonitoring --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_customise_SoftDisplacedVerticesMC --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_filter_SoftDisplacedVertices --conditions 106X_mc2017_realistic_v9 --procModifiers run2_miniAOD_UL --geometry DB:Extended --era Run2_2017 --runUnscheduled --no_exec --mc
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
 
 from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 
-process = cms.Process('PAT',Run2_2017,run2_miniAOD_UL)
+process = cms.Process('MINI',Run2_2017,run2_miniAOD_UL)
+
+options = VarParsing ('analysis')
+options.parseArguments()
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -24,12 +28,12 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1)
+    input = cms.untracked.int32(options.maxEvents)
 )
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:AOD.root'),
+    fileNames = cms.untracked.vstring(options.inputFiles),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -56,7 +60,7 @@ process.MINIAODSIMoutput = cms.OutputModule("PoolOutputModule",
     dropMetaData = cms.untracked.string('ALL'),
     eventAutoFlushCompressedSize = cms.untracked.int32(-900),
     fastCloning = cms.untracked.bool(False),
-    fileName = cms.untracked.string('MiniAOD.root'),
+    fileName = cms.untracked.string(options.outputFile),
     outputCommands = process.MINIAODSIMEventContent.outputCommands,
     overrideBranchesSplitLevel = cms.untracked.VPSet(
         cms.untracked.PSet(

--- a/CustomMiniAOD/configuration/MC_UL17_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/MC_UL17_CustomMiniAOD.py
@@ -194,7 +194,7 @@ process = miniAOD_customizeAllMC(process)
 # End of customisation functions
 
 # Customisation from command line
-
+process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=1000
 # Add early deletion of temporary data products to reduce peak memory need
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
 process = customiseEarlyDelete(process)

--- a/CustomMiniAOD/configuration/MC_UL18_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/MC_UL18_CustomMiniAOD.py
@@ -194,7 +194,7 @@ process = miniAOD_customizeAllMC(process)
 # End of customisation functions
 
 # Customisation from command line
-
+process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=1000
 # Add early deletion of temporary data products to reduce peak memory need
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
 process = customiseEarlyDelete(process)

--- a/CustomMiniAOD/configuration/MC_UL18_CustomMiniAOD.py
+++ b/CustomMiniAOD/configuration/MC_UL18_CustomMiniAOD.py
@@ -4,11 +4,15 @@
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
 # with command line options: CustomMiniAOD --python_filename MC_UL18_CustomMiniAOD.py --filein file:AOD.root --fileout MiniAOD.root --step PAT --eventcontent MINIAODSIM --datatier MINIAODSIM --customise Configuration/DataProcessing/Utils.addMonitoring --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_customise_SoftDisplacedVerticesMC --customise SoftDisplacedVertices/CustomMiniAOD/miniAOD_cff.miniAOD_filter_SoftDisplacedVertices --conditions 106X_upgrade2018_realistic_v16_L1v1 --procModifiers run2_miniAOD_UL --geometry DB:Extended --era Run2_2018 --runUnscheduled --no_exec --mc
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
 
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 
-process = cms.Process('PAT',Run2_2018,run2_miniAOD_UL)
+process = cms.Process('MINI',Run2_2018,run2_miniAOD_UL)
+
+options = VarParsing ('analysis')
+options.parseArguments()
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -24,12 +28,12 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1)
+    input = cms.untracked.int32(options.maxEvents)
 )
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:AOD.root'),
+    fileNames = cms.untracked.vstring(options.inputFiles),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -56,7 +60,7 @@ process.MINIAODSIMoutput = cms.OutputModule("PoolOutputModule",
     dropMetaData = cms.untracked.string('ALL'),
     eventAutoFlushCompressedSize = cms.untracked.int32(-900),
     fastCloning = cms.untracked.bool(False),
-    fileName = cms.untracked.string('MiniAOD.root'),
+    fileName = cms.untracked.string(options.outputFile),
     outputCommands = process.MINIAODSIMEventContent.outputCommands,
     overrideBranchesSplitLevel = cms.untracked.VPSet(
         cms.untracked.PSet(

--- a/CustomMiniAOD/testK/Data_UL18_CustomMiniAOD.py
+++ b/CustomMiniAOD/testK/Data_UL18_CustomMiniAOD.py
@@ -193,7 +193,7 @@ process = miniAOD_customizeAllData(process)
 # End of customisation functions
 
 # Customisation from command line
-process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=1000
+# process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=1000
 # Add early deletion of temporary data products to reduce peak memory need
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
 process = customiseEarlyDelete(process)

--- a/CustomNanoAOD/README.md
+++ b/CustomNanoAOD/README.md
@@ -1,0 +1,4 @@
+# CustomNanoAOD
+NanoAOD customisation for soft displaced vertex search.
+
+This follows the same structure of the `CustomMiniAOD` directory.

--- a/CustomNanoAOD/configuration/MC_UL16_CustomNanoAOD.py
+++ b/CustomNanoAOD/configuration/MC_UL16_CustomNanoAOD.py
@@ -4,11 +4,15 @@
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
 # with command line options: NANO -s NANO --python_filename MC_UL16_CustomNanoAOD.py --filein file:MiniAOD.root --fileout NanoAOD.root --mc --conditions 106X_mcRun2_asymptotic_v17 --era Run2_2016,run2_nanoAOD_106Xv2 --eventcontent NANOAODSIM --datatier NANOAODSIM --customise_commands=process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=1000 --customise SoftDisplacedVertices/CustomNanoAOD/nanoAOD_cff.nanoAOD_customise_SoftDisplacedVerticesMC -n -1 --no_exec --nThreads 4
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
 
 from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 from Configuration.Eras.Modifier_run2_nanoAOD_106Xv2_cff import run2_nanoAOD_106Xv2
 
 process = cms.Process('NANO',Run2_2016,run2_nanoAOD_106Xv2)
+
+options = VarParsing ('analysis')
+options.parseArguments()
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -23,12 +27,12 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
+    input = cms.untracked.int32(options.maxEvents)
 )
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:MiniAOD.root'),
+    fileNames = cms.untracked.vstring(options.inputFiles),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -52,7 +56,7 @@ process.NANOAODSIMoutput = cms.OutputModule("NanoAODOutputModule",
         dataTier = cms.untracked.string('NANOAODSIM'),
         filterName = cms.untracked.string('')
     ),
-    fileName = cms.untracked.string('NanoAOD.root'),
+    fileName = cms.untracked.string(options.outputFile),
     outputCommands = process.NANOAODSIMEventContent.outputCommands
 )
 

--- a/CustomNanoAOD/configuration/MC_UL16preVFP_CustomNanoAOD.py
+++ b/CustomNanoAOD/configuration/MC_UL16preVFP_CustomNanoAOD.py
@@ -4,11 +4,15 @@
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
 # with command line options: NANO -s NANO --python_filename MC_UL16preVFP_CustomNanoAOD.py --filein file:MiniAOD.root --fileout NanoAOD.root --mc --conditions 106X_mcRun2_asymptotic_preVFP_v11 --era Run2_2016_HIPM,run2_nanoAOD_106Xv2 --eventcontent NANOAODSIM --datatier NANOAODSIM --customise_commands=process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=1000 --customise SoftDisplacedVertices/CustomNanoAOD/nanoAOD_cff.nanoAOD_customise_SoftDisplacedVerticesMC -n -1 --no_exec --nThreads 4
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
 
 from Configuration.Eras.Era_Run2_2016_HIPM_cff import Run2_2016_HIPM
 from Configuration.Eras.Modifier_run2_nanoAOD_106Xv2_cff import run2_nanoAOD_106Xv2
 
 process = cms.Process('NANO',Run2_2016_HIPM,run2_nanoAOD_106Xv2)
+
+options = VarParsing ('analysis')
+options.parseArguments()
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -23,12 +27,12 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
+    input = cms.untracked.int32(options.maxEvents)
 )
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:MiniAOD.root'),
+    fileNames = cms.untracked.vstring(options.inputFiles),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -52,7 +56,7 @@ process.NANOAODSIMoutput = cms.OutputModule("NanoAODOutputModule",
         dataTier = cms.untracked.string('NANOAODSIM'),
         filterName = cms.untracked.string('')
     ),
-    fileName = cms.untracked.string('NanoAOD.root'),
+    fileName = cms.untracked.string(options.outputFile),
     outputCommands = process.NANOAODSIMEventContent.outputCommands
 )
 

--- a/CustomNanoAOD/configuration/MC_UL17_CustomNanoAOD.py
+++ b/CustomNanoAOD/configuration/MC_UL17_CustomNanoAOD.py
@@ -4,11 +4,15 @@
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
 # with command line options: NANO -s NANO --python_filename MC_UL17_CustomNanoAOD.py --filein file:MiniAOD.root --fileout NanoAOD.root --mc --conditions 106X_mc2017_realistic_v9 --era Run2_2017,run2_nanoAOD_106Xv2 --eventcontent NANOAODSIM --datatier NANOAODSIM --customise_commands=process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=1000 --customise SoftDisplacedVertices/CustomNanoAOD/nanoAOD_cff.nanoAOD_customise_SoftDisplacedVerticesMC -n -1 --no_exec --nThreads 4
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
 
 from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
 from Configuration.Eras.Modifier_run2_nanoAOD_106Xv2_cff import run2_nanoAOD_106Xv2
 
 process = cms.Process('NANO',Run2_2017,run2_nanoAOD_106Xv2)
+
+options = VarParsing ('analysis')
+options.parseArguments()
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -23,12 +27,12 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
+    input = cms.untracked.int32(options.maxEvents)
 )
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:MiniAOD.root'),
+    fileNames = cms.untracked.vstring(options.inputFiles),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -52,7 +56,7 @@ process.NANOAODSIMoutput = cms.OutputModule("NanoAODOutputModule",
         dataTier = cms.untracked.string('NANOAODSIM'),
         filterName = cms.untracked.string('')
     ),
-    fileName = cms.untracked.string('NanoAOD.root'),
+    fileName = cms.untracked.string(options.outputFile),
     outputCommands = process.NANOAODSIMEventContent.outputCommands
 )
 

--- a/CustomNanoAOD/configuration/MC_UL18_CustomNanoAOD.py
+++ b/CustomNanoAOD/configuration/MC_UL18_CustomNanoAOD.py
@@ -4,11 +4,16 @@
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
 # with command line options: NANO -s NANO --python_filename MC_UL18_CustomNanoAOD.py --filein file:MiniAOD.root --fileout NanoAOD.root --mc --conditions 106X_upgrade2018_realistic_v16_L1v1 --era Run2_2018,run2_nanoAOD_106Xv2 --eventcontent NANOAODSIM --datatier NANOAODSIM --customise_commands=process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)));process.MessageLogger.cerr.FwkReport.reportEvery=1000 --customise SoftDisplacedVertices/CustomNanoAOD/nanoAOD_cff.nanoAOD_customise_SoftDisplacedVerticesMC -n -1 --no_exec --nThreads 4
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
+
 
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 from Configuration.Eras.Modifier_run2_nanoAOD_106Xv2_cff import run2_nanoAOD_106Xv2
 
 process = cms.Process('NANO',Run2_2018,run2_nanoAOD_106Xv2)
+
+options = VarParsing ('analysis')
+options.parseArguments()
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -23,12 +28,12 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
+    input = cms.untracked.int32(options.maxEvents)
 )
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:MiniAOD.root'),
+    fileNames = cms.untracked.vstring(options.inputFiles),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -52,7 +57,7 @@ process.NANOAODSIMoutput = cms.OutputModule("NanoAODOutputModule",
         dataTier = cms.untracked.string('NANOAODSIM'),
         filterName = cms.untracked.string('')
     ),
-    fileName = cms.untracked.string('NanoAOD.root'),
+    fileName = cms.untracked.string(options.outputFile),
     outputCommands = process.NANOAODSIMEventContent.outputCommands
 )
 

--- a/README.md
+++ b/README.md
@@ -1,50 +1,18 @@
 # SoftDisplacedVertices
 Framework for Soft Displaced Vertices analysis.
 
-This package is currently in a very preliminary stage. Tracks are selected and passed to the **InclusiveVertexFinder** to reconstruct secondary vertices.
+This package is currently in a preliminary stage. Tracks are selected and passed to the **InclusiveVertexFinder** to reconstruct secondary vertices.
 
-This version utilizes the chain:
+The extension of standard MiniAOD and NanoAOD is done by applying the same set of conditions, calibrations, and alignments in the standard processing chain.  
+For instance our 2018 RunII MC reprocessing chain is based on the following:  
  [SUS-chain_RunIISummer20UL18wmLHEGEN_flowRunIISummer20UL18SIM_flowRunIISummer20UL18DIGIPremix_flowRunIISummer20UL18HLT_flowRunIISummer20UL18RECO_flowRunIISummer20UL18MiniAODv2_flowRunIISummer20UL18NanoAODv9-00066](https://cms-pdmv.cern.ch/mcm/chained_requests?prepid=SUS-chain_RunIISummer20UL18wmLHEGEN_flowRunIISummer20UL18SIM_flowRunIISummer20UL18DIGIPremix_flowRunIISummer20UL18HLT_flowRunIISummer20UL18RECO_flowRunIISummer20UL18MiniAODv2_flowRunIISummer20UL18NanoAODv9-00066).
 
-[SUS-RunIISummer20UL18MiniAODv2-00068](https://cms-pdmv.cern.ch/mcm/requests?prepid=SUS-RunIISummer20UL18MiniAODv2-00068&page=0), is the first file we generate. \
-[SUS-RunIISummer20UL18NanoAODv9-00068](https://cms-pdmv.cern.ch/mcm/requests?prepid=SUS-RunIISummer20UL18NanoAODv9-00068&page=0) is the final product.
+We first generate a customised version of [SUS-RunIISummer20UL18MiniAODv2-00068](https://cms-pdmv.cern.ch/mcm/requests?prepid=SUS-RunIISummer20UL18MiniAODv2-00068&page=0), \
+and then a customised version of [SUS-RunIISummer20UL18NanoAODv9-00068](https://cms-pdmv.cern.ch/mcm/requests?prepid=SUS-RunIISummer20UL18NanoAODv9-00068&page=0).
 
 For different MC files it might be worth checking:
  - [History of MC Production Campaigns](https://twiki.cern.ch/twiki/bin/viewauth/CMS/PdmVMcCampaigns)
  - [NanoAOD Specific Explanations for the MC Campaigns](https://gitlab.cern.ch/cms-nanoAOD/nanoaod-doc/-/wikis/home)
-
-\
-In this repository there are two configuration files (*_cfg.py) that can be run by cmsRun:
-
- - customMiniAODv2_cfg.py: Produces miniAODv2 and appends a custom collection of filtered reco::Tracks.
-
- - customNanoAOD_cfg.py: Reconstructs secondary vertices, and produces NanoAOD. The output (nanoAOD) contains only flat n-tuples.
-
-To set up the environment:
-```
-cmsrel CMSSW_10_6_27
-cd CMSSW_10_6_27/src
-git clone git@github.com:HephyAnalysisSW/SoftDisplacedVertices.git
-git checkout main
-scram b -j8
-```
-
-
-
-To produce miniAOD:
-```
-cd CMSSW_10_6_27/src/CustomMiniAOD/test_cfg
-cmsenv
-bash MC_UL18_CustomMiniAOD.sh
-```
-
-To produce nanoAOD:
-```
-cd CMSSW_10_6_27/src/CustomNanoAOD/test_cfg
-cmsenv
-bash MC_UL18_CustomNanoAOD.sh
-```
-
-N.B. Please modify the paths to the input and output files in:
- - SoftDisplacedVertices/CustomMiniAOD/test_cfg/MC_UL18_CustomMiniAOD.sh
- - SoftDisplacedVertices/CustomNanoAOD/test_cfg/MC_UL18_CustomNanoAOD.sh
+  
+  
+Check out the subdirectories of this repository to find more about the production.

--- a/SoftDVDataFormats/README.md
+++ b/SoftDVDataFormats/README.md
@@ -1,0 +1,6 @@
+# SoftDVDataFormats
+Soft Displaced Vertex Data Formats
+
+When you want to produce a non-standard data format , class etc. via the EDProducer these must be defined by a set of instructions.  
+Refer to [SWGuideCreatingNewProducts](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCreatingNewProducts) for more info.
+


### PR DESCRIPTION
configuration directory already contained valuable config files for the cmsRun for different periods of RunII.
They were like templates as their input and output files were generic.
Now they accept command-line arguments. 

README files are updated for our new collaborators.
Using the configuration directory is the recommended way for production now.