### PR TITLE
resolve the misleading gen matching information

### DIFF
--- a/CustomNanoAOD/plugins/LLPTableProducer.cc
+++ b/CustomNanoAOD/plugins/LLPTableProducer.cc
@@ -187,7 +187,6 @@ void LLPTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
       int match_ntk = vtxllpmatch[ivtx].second;
       SDV_match_bydau[ivtx] = llp_matched_idx;
       SDV_match_bydau_ntk[ivtx] = match_ntk;
-      llp_match_bydau_ntk[llp_matched_idx] = match_ntk;
       math::XYZPoint llp_decay = math::XYZPoint(llp_decay_x[llp_matched_idx], llp_decay_y[llp_matched_idx], llp_decay_z[llp_matched_idx]);
       if (llp_match_bydau_ntk[llp_matched_idx] < match_ntk) {
         llp_match_bydau_ntk[llp_matched_idx] = match_ntk;

--- a/SoftDVDataFormats/src/GenInfo.cc
+++ b/SoftDVDataFormats/src/GenInfo.cc
@@ -252,7 +252,9 @@ std::map<int,std::pair<int,int>> SoftDV::VtxLLPMatch(const edm::Handle<reco::Gen
     else{
       // Pick the LLP that have most number of matched track with the vertex as matched LLP
       int matchllp_idx = std::max_element(nmatchtk.begin(),nmatchtk.end())-nmatchtk.begin();
-      res[ivtx] = std::pair<int,int>(matchllp_idx,nmatchtk[matchllp_idx]);
+      if (nmatchtk[matchllp_idx]>0){
+        res[ivtx] = std::pair<int,int>(matchllp_idx,nmatchtk[matchllp_idx]);
+      }
     }
   }
   return res;


### PR DESCRIPTION
This solves two bugs/misleading information of the gen matching of LLPs:
- `LLP_matchedSDVIdx_bydau` used to be empty and now it has the matched SDV index (match means have at least 1 matched track)
- `SDVSecVtx_matchedLLPIdx_bydau` used to have unmatched LLPs at value 0, now it is assigned -1.